### PR TITLE
Replace system-filepath dependency (deprecated) with filepath package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cabal-dev
 dist
 TAGS
+.stack-work/

--- a/imagemagick.cabal
+++ b/imagemagick.cabal
@@ -75,7 +75,7 @@ Library
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , MonadCatchIO-transformers == 0.3.*
   extensions:         EmptyDataDecls
   Ghc-options:        -Wall
@@ -95,7 +95,7 @@ executable            resize
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -114,7 +114,7 @@ executable            extent
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && < 1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -133,7 +133,7 @@ executable            floodfill
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -153,7 +153,7 @@ executable            cyclops
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -172,7 +172,7 @@ executable            clipmask
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -190,7 +190,7 @@ executable            paint-trans
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && < 1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -210,7 +210,7 @@ executable            round-mask
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -229,7 +229,7 @@ executable            make-tile
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && < 1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -247,7 +247,7 @@ executable            draw-shapes
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -266,7 +266,7 @@ executable            text-effects
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -285,7 +285,7 @@ executable            gel
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , lifted-base >= 0.1 && <0.3
                       , imagemagick
   Else
@@ -304,7 +304,7 @@ executable            reflect
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -323,7 +323,7 @@ executable            3dlogo
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -342,7 +342,7 @@ executable            affine
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -361,7 +361,7 @@ executable            grayscale
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -380,7 +380,7 @@ executable            modulate
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -400,7 +400,7 @@ executable            landscape3d
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -419,7 +419,7 @@ executable            tilt-shift
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -438,7 +438,7 @@ executable            bunny
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -457,7 +457,7 @@ executable            pixel-mod
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -476,7 +476,7 @@ executable            wandtest
                       , vector >= 0.9 && <0.11
                       , bytestring >= 0.9 && <0.11
                       , text >= 0.11 && <1.3
-                      , system-filepath == 0.4.*
+                      , filepath >= 1.0
                       , imagemagick
   Else
     Buildable:        False
@@ -496,7 +496,7 @@ test-suite           image-tests
                      , vector >= 0.9 && <0.11
                      , bytestring >= 0.9 && <0.11
                      , text >= 0.11 && <1.3
-                     , system-filepath == 0.4.*
+                     , filepath >= 1.0
                      , imagemagick
                      , QuickCheck >= 2
                      , HUnit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags:
+  imagemagick:
+    buildexamples: false
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.6


### PR DESCRIPTION
Hi! Just wanted to propose an update to resolve some minor issues I encountered with the FilePath type. Being completely new to imagemagick, I realized that the `FilePath` type isn't simply an alias to `String`. 

Of course, feedback is most welcome--especially if there's a better approach. 

A `stack.yaml` file is also include for Stackage support.

See deprecation announcement for system-filepath: 
https://plus.google.com/+MichaelSnoyman/posts/Ft5hnPqpgEx